### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 > [Kap](https://github.com/wulkano/kap) plugin - Record the system audio using Soundflower
 
 ## Install
-
-In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this plugin, and toggle it.
+1. Download [lastest soundflower release](https://github.com/mattingalls/Soundflower/releases).
+2. In the `Kap` menu, go to `Preferences…`, select the `Plugins` pane, find this plugin, and toggle it.
 
 ## Usage
 


### PR DESCRIPTION
Readme tip that helps to solve the following issue:

```
Something went wrong while using the plugin “soundflower”

Error: Built-in Microphone is not an output device
    at throwIfStderr (/macos-audio-devices/index.js:22:11)
    at module.exports.<computed> (/macos-audio-devices/index.js:11:12)
    at async Object.willStartRecording (/kap-soundflower/index.js:96:3)
    at async /Applications/Kap.app/Contents/Resources/app.asar/main/common/aperture.js:56:7
    at async Promise.all (index 0)
    at async Object.startRecording (/Applications/Kap.app/Contents/Resources/app.asar/main/common/aperture.js:148:3)
```